### PR TITLE
Improve source node variable logic in Grafana dashboards

### DIFF
--- a/grafana-dashboards/neighbor-info-nodes.json
+++ b/grafana-dashboards/neighbor-info-nodes.json
@@ -327,20 +327,21 @@
           "type": "prometheus",
           "uid": "a7ee7fd2-ee1a-4400-b169-afa1f8c619ed"
         },
-        "definition": "meshtastic_neighbor_info_snr_decibels",
+        "definition": "meshtastic_mesh_packets_total",
         "hide": 0,
         "includeAll": false,
-        "multi": false,
+        "multi": true,
         "name": "source",
         "options": [],
         "query": {
-          "query": "meshtastic_neighbor_info_snr_decibels",
+          "qryType": 4,
+          "query": "meshtastic_mesh_packets_total",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "/source_long_name=\"(?<text>[^\"]+)|source=\"(?<value>[^\"]+)/g",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 5,
         "type": "query"
       }
     ]
@@ -353,6 +354,6 @@
   "timezone": "",
   "title": "Meshtastic Neighbor Info (Nodes)",
   "uid": "a8711380-ea8b-43d3-931a-e7233e8189f1",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/grafana-dashboards/packets-nodes.json
+++ b/grafana-dashboards/packets-nodes.json
@@ -502,20 +502,21 @@
           "type": "prometheus",
           "uid": "a7ee7fd2-ee1a-4400-b169-afa1f8c619ed"
         },
-        "definition": "meshtastic_node_info_last_heard_timestamp_seconds",
+        "definition": "meshtastic_mesh_packets_total",
         "hide": 0,
         "includeAll": false,
-        "multi": false,
+        "multi": true,
         "name": "source",
         "options": [],
         "query": {
-          "query": "meshtastic_node_info_last_heard_timestamp_seconds",
+          "qryType": 4,
+          "query": "meshtastic_mesh_packets_total",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "/source_long_name=\"(?<text>[^\"]+)|source=\"(?<value>[^\"]+)/g",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 5,
         "type": "query"
       }
     ]
@@ -528,6 +529,6 @@
   "timezone": "",
   "title": "Meshtastic Packets (Nodes)",
   "uid": "dfe109f7-17b6-467b-97bf-2e9c6508e0fc",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/grafana-dashboards/telemetry-nodes.json
+++ b/grafana-dashboards/telemetry-nodes.json
@@ -940,20 +940,21 @@
           "type": "prometheus",
           "uid": "a7ee7fd2-ee1a-4400-b169-afa1f8c619ed"
         },
-        "definition": "meshtastic_node_info_last_heard_timestamp_seconds",
+        "definition": "meshtastic_mesh_packets_total",
         "hide": 0,
         "includeAll": false,
-        "multi": false,
+        "multi": true,
         "name": "source",
         "options": [],
         "query": {
-          "query": "meshtastic_node_info_last_heard_timestamp_seconds",
+          "qryType": 4,
+          "query": "meshtastic_mesh_packets_total",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "/source_long_name=\"(?<text>[^\"]+)|source=\"(?<value>[^\"]+)/g",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 5,
         "type": "query"
       }
     ]
@@ -966,6 +967,6 @@
   "timezone": "",
   "title": "Meshtastic Telemetry (Nodes)",
   "uid": "a7ca7097-db42-4515-8bea-d9d2b9d1b117",
-  "version": 21,
+  "version": 22,
   "weekStart": ""
 }


### PR DESCRIPTION
Now source variable does not depend too much on node info packets, and instead can be taken from any packet the node has sent